### PR TITLE
Support opening a StringsMmap read-only

### DIFF
--- a/python/mmap_ninja/string.py
+++ b/python/mmap_ninja/string.py
@@ -97,7 +97,8 @@ class StringsMmap:
         self.ends = numpy.open_existing(self.out_dir / self.ends_key, mode="r")
         self.range = np.arange(len(self.starts), dtype=np.int64)
         self.file = open(self.data_file, mode=self.mode)
-        self.buffer = mmap.mmap(self.file.fileno(), 0)
+        access = mmap.ACCESS_READ if self.mode == 'rb' else mmap.ACCESS_DEFAULT
+        self.buffer = mmap.mmap(self.file.fileno(), 0, access=access)
 
     def append(self, string: str):
         self.extend([string])

--- a/python/tests/test_numpy.py
+++ b/python/tests/test_numpy.py
@@ -1,3 +1,6 @@
+import os
+import stat
+
 import numpy as np
 
 from mmap_ninja import numpy as np_ninja, generic
@@ -67,3 +70,18 @@ def test_numpy_from_generator(tmp_path):
     memmap = np_ninja.open_existing(tmp_path / "generator")
     for i in range(30):
         assert i == memmap[i]
+
+
+def test_read_only(tmp_path):
+    out_path = tmp_path / 'read_only_numpy_memmap'
+    arr = np.arange(10)
+    np_ninja.from_ndarray(out_path, arr)
+    # Make all memmap files read-only for the user
+    for p in out_path.glob(r'**/*'):
+        if not p.is_file():
+            continue
+        os.chmod(p, stat.S_IRUSR)
+    # Open in read-only mode
+    memmap = np_ninja.open_existing(out_path, mode='r')
+    for i, el in enumerate(arr):
+        assert el == memmap[i]

--- a/python/tests/test_string.py
+++ b/python/tests/test_string.py
@@ -1,4 +1,6 @@
 import json
+import os
+import stat
 
 import pytest
 
@@ -86,3 +88,18 @@ def test_json_wrapper(tmp_path):
 
     memmap = generic.open_existing(tmp_path / "strings_memmap", wrapper_fn=json.loads)
     print(memmap[0])
+
+
+def test_read_only(tmp_path):
+    out_path = tmp_path / 'read_only_str_memmap'
+    list_of_strings = ['This is the first test string...', '... and the second one.']
+    StringsMmap.from_strings(out_dir=out_path, strings=list_of_strings)
+    # Make all memmap files read-only for the user
+    for p in out_path.glob(r'**/*'):
+        if not p.is_file():
+            continue
+        os.chmod(p, stat.S_IRUSR)
+    # Open in read-only mode
+    memmap = StringsMmap(out_dir=out_path, mode='rb')
+    for i, string in enumerate(list_of_strings):
+        assert string == memmap[i]


### PR DESCRIPTION
This PR addresses opening a `StringsMmap` read-only as mentioned in #10.

It also adds relevant unit tests to ensure that opening an existing `StringsMmap`, `mmap_ninja.numpy` memory map or a `RaggedMmap` in read-only mode is working properly.