### PR TITLE
Better progress bar for notebooks

### DIFF
--- a/mmap_ninja/src/mmap_ninja/base.py
+++ b/mmap_ninja/src/mmap_ninja/base.py
@@ -203,7 +203,7 @@ def from_generator_base(out_dir, sample_generator, batch_size, batch_ctor, exten
     samples = []
     memmap = None
     if kwargs.pop("verbose", False):
-        from tqdm import tqdm
+        from tqdm.auto import tqdm
 
         sample_generator = tqdm(sample_generator)
     for sample in sample_generator:


### PR DESCRIPTION
This is a simple change that changes the default representation of the `tqdm` progress bar depending on the context. In a terminal environment, it will use the default ASCII representation, and on Jupyter you get an HTML progress bar.

<img width="825" alt="image" src="https://github.com/hristo-vrigazov/mmap.ninja/assets/7668305/ebe486ea-1122-4634-a7d0-81a63606eec0">
